### PR TITLE
339: wrong color in interview list

### DIFF
--- a/interview/models.py
+++ b/interview/models.py
@@ -615,7 +615,7 @@ class Interview(models.Model):
         return self.planned_date is not None or self.state == self.WAITING_PLANIFICATION_RESPONSE
 
     def toggle_planning_request(self):
-        if self.state == self.WAITING_PLANIFICATION:
+        if self.state in [self.WAITING_PLANIFICATION, self.DRAFT]:
             self.state = self.WAITING_PLANIFICATION_RESPONSE
         elif self.state == self.WAITING_PLANIFICATION_RESPONSE:
             self.state = self.WAITING_PLANIFICATION


### PR DESCRIPTION
fixes #339 
Not 100% sure this is the 'correct' bug to fix

Steps to reproduce bug with previous behavior
- add interview
- click CR button
- save as draft ( user error who did not mean actually to save report )

The interview date now if fixed at the time the report was drafted
Removing the date make the toggle button appear again but does not do anything when clicked

Now:
- Toggle reverts state to WAITING_PLANIFICATION_RESPONSE / WAITING_PLANIFICATION even from DRAFT state 
- Allows to revert back to correct state which was not possible before
- report text is still saved

```mermaid
graph TD;
    DRAFT-->|toggle|WAITING_PLANIFICATION_RESPONSE ;
    WAITING_PLANIFICATION_RESPONSE -->|toggle|WAITING_PLANIFICATION;
    WAITING_PLANIFICATION-->|toggle|WAITING_PLANIFICATION_RESPONSE ;
```

Allowing the line to be in the wanted state and correct color