### PR TITLE
Implemented cache busting for prod by using ManifestStaticFilesStorage to handle static files (Fixes #71)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v1.24.0 (XXXX-XX-XX)
+- Implemented cache busting for prod by using ManifestStaticFilesStorage to handle static files
+
 # v1.23.1 (2025-02-23)
 - Improve kanban view
   - fix legend

--- a/pyoupyou/settings/common.py
+++ b/pyoupyou/settings/common.py
@@ -107,7 +107,7 @@ CRISPY_TEMPLATE_PACK = "bootstrap3"
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/1.10/howto/static-files/
 
-STATIC_ROOT = "static/"
+STATIC_ROOT = BASE_DIR / "static"
 STATIC_URL = "/static/"
 MEDIA_ROOT = BASE_DIR / "media"
 MEDIA_URL = "/media/"

--- a/pyoupyou/settings/prod.py
+++ b/pyoupyou/settings/prod.py
@@ -1,2 +1,12 @@
 DEBUG = False
 HAS_DDT = False
+
+# ManifestStaticFilesStorage adds MD5 hash to filenames for cache busting
+STORAGES = {
+    "default": {
+        "BACKEND": "django.core.files.storage.FileSystemStorage",
+    },
+    "staticfiles": {
+        "BACKEND": "django.contrib.staticfiles.storage.ManifestStaticFilesStorage",
+    },
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,34 +1,96 @@
 asgiref==3.8.1
+    # via django
 bleach==5.0.1
+    # via django-bleach
 certifi==2025.1.31
+    # via requests
 charset-normalizer==3.4.1
+    # via requests
 django==5.1.6
+    # via
+    #   django-appconf
+    #   django-bleach
+    #   django-extensions
+    #   django-filter
+    #   django-ical
+    #   django-recurrence
+    #   django-select2
+    #   django-tables2
+    #   djangorestframework
+    #   pyoupyou
 django-appconf==1.1.0
+    # via django-select2
 django-bleach==3.1.0
+    # via pyoupyou
 django-bootstrap-static==3.3.7.2
+    # via pyoupyou
 django-crispy-forms==1.14.0
+    # via pyoupyou
 django-extensions==3.2.3
+    # via pyoupyou
 django-filter==25.1
+    # via pyoupyou
 django-ical==1.9.2
+    # via pyoupyou
 django-recurrence==1.11.1
+    # via django-ical
 django-select2==8.3.0
+    # via pyoupyou
 django-split-settings==1.2.0
+    # via pyoupyou
 django-tables2==2.7.5
+    # via pyoupyou
 djangorestframework==3.15.2
+    # via pyoupyou
 icalendar==6.1.1
+    # via django-ical
 idna==3.10
+    # via requests
 markdown-it-py==3.0.0
+    # via pyoupyou
 mdurl==0.1.2
+    # via markdown-it-py
 numpy==2.2.3
+    # via
+    #   pandas
+    #   pyoupyou
 pandas==2.2.3
+    # via pyoupyou
 plotly==4.8.2
+    # via pyoupyou
 python-dateutil==2.9.0.post0
+    # via
+    #   django-recurrence
+    #   icalendar
+    #   pandas
 pytz==2025.1
+    # via
+    #   pandas
+    #   pyoupyou
 requests==2.32.3
+    # via pyoupyou
 retrying==1.3.4
+    # via plotly
 six==1.17.0
+    # via
+    #   bleach
+    #   plotly
+    #   python-dateutil
+    #   retrying
 sqlparse==0.5.3
+    # via django
 tinycss2==1.1.1
+    # via bleach
 tzdata==2025.1
+    # via
+    #   django
+    #   icalendar
+    #   pandas
 urllib3==2.3.0
+    # via
+    #   pyoupyou
+    #   requests
 webencodings==0.5.1
+    # via
+    #   bleach
+    #   tinycss2


### PR DESCRIPTION
**Changes :** 

- Updated [STORAGES] configuration to use ManifestStaticFilesStorage in production
- Maintained StaticFilesStorage in development for fast iteration
- Updated CHANGELOG.md

**Note :** 

- In production, static files are available at the staticfiles/ folder in the project's root directory

Resolves: #71