### PR TITLE
Allow interviewers to view processes/minutes regardless of seniority if involved in the process (Fixes #280)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 - Implemented cache busting for prod by using ManifestStaticFilesStorage to handle static files
 - Changed pivotable and js/css dependencies to static loading instead of cdn
 - Allow multiple file uploads when creating/editing candidate
+- Users involved in a process can now view all related interviews and minutes, regardless of when the process started
 
 # v1.23.1 (2025-02-23)
 - Improve kanban view

--- a/interview/models.py
+++ b/interview/models.py
@@ -508,7 +508,7 @@ class InterviewManager(models.Manager):
         q = (
             super(InterviewManager, self)
             .get_queryset()
-            .filter(Q(process__start_date__gte=user.date_joined) | Q(interviewers__in=[user]))
+            .filter(Q(process__start_date__gte=user.date_joined) | Q(process__interview__interviewers=user))
             .distinct()
         )
         if user.is_external:


### PR DESCRIPTION
- Changed rule for viewing interviews : if a user is involved in a process, he can view all its related interviews and minutes, regardless of if the process predates his own recruitment

- Added relevant tests

Resolves : #280 