### PR TITLE
Added minutes & objective draft client-side autosave (resolves #350)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # v1.24.0 (XXXX-XX-XX)
+- Added client-side autosave for interview minutes drafts and objective drafts (two-week retention)
 - Implemented cache busting for prod by using ManifestStaticFilesStorage to handle static files
 - Changed pivotable and js/css dependencies to static loading instead of cdn
 - Allow multiple file uploads when creating/editing candidate

--- a/interview/templates/interview/interview_minute_form.html
+++ b/interview/templates/interview/interview_minute_form.html
@@ -37,8 +37,75 @@
             $(this).on('click', (event) => {
                 delete_document(event.target.id)
             });
-        })
+        });
+
+        // LocalStorage autosave for minute & next_interview_goal
+        const INTERVIEW_ID = {{ interview.id }};
+        const USER_ID = {{ request.user.id }};
+        const STORAGE_KEY = `interview_minute_${INTERVIEW_ID}_${USER_ID}`;
+        const EXPIRATION_DAYS = 14;
+
+        function saveDraft() {
+            const data = {
+                minute: $('#id_minute').val(),
+                next_interview_goal: $('#id_next_interview_goal').val(),
+                timestamp: Date.now()
+            };
+            localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+        }
+
+        function loadDraft() {
+            const saved = localStorage.getItem(STORAGE_KEY);
+            if (saved) {
+                const data = JSON.parse(saved);
+                const age = Date.now() - data.timestamp;
+                const maxAge = EXPIRATION_DAYS * 24 * 60 * 60 * 1000;
+
+                if (age > maxAge) {
+                    localStorage.removeItem(STORAGE_KEY);$
+                    return;
+                }
+
+                // Restore if text area is empty
+                if ($('#id_minute').val() === '') {
+                    $('#id_minute').val(data.minute);
+                }
+                if ($('#id_next_interview_goal').val() === '') {
+                    $('#id_next_interview_goal').val(data.next_interview_goal);
+                }
+            }
+        }
+
+        function cleanupOldDrafts() {
+            const prefix = 'interview_minute_';
+            const maxAge = EXPIRATION_DAYS * 24 * 60 * 60 * 1000;
+
+            for (let i = 0; i < localStorage.length; i++) {
+                const key = localStorage.key(i);
+                if (key && key.startsWith(prefix)) {
+                    const saved = localStorage.getItem(key);
+                    if (saved) {
+                        try {
+                            const data = JSON.parse(saved);
+                            if (Date.now() - data.timestamp > maxAge) {
+                                localStorage.removeItem(key);
+                            }
+                        } catch (e) {}
+                    }
+                }
+            }
+        }
+
+        let saveTimeout;
+        $('#id_minute, #id_next_interview_goal').on('input', function() {
+            clearTimeout(saveTimeout);
+            saveTimeout = setTimeout(saveDraft, 500);
+        });
+
+        loadDraft();
+        cleanupOldDrafts();
     });
+
 </script>
 {% endblock %}
 


### PR DESCRIPTION
## Changes
- Added autosave for user drafts - for minutes and objectives text areas (in `/interview/{interview_id}/minute/edit/`) - to browser's localStorage.
- Drafts are kept for two weeks after their last modifications