### PR TITLE
create_dev_dataset: append ADMIN to admin's user name

### DIFF
--- a/interview/management/commands/create_dev_dataset.py
+++ b/interview/management/commands/create_dev_dataset.py
@@ -107,6 +107,7 @@ class Command(BaseCommand):
             admin = subsidiary_pyoupyou_users[0]
             admin.is_superuser = True
             admin.is_staff = True
+            admin.full_name += "(ADMIN)"
             admin.save()
 
             # set subsidiary's responsible


### PR DESCRIPTION
This makes it much clearer to know which user is the admin when switching to user during development from DjDT